### PR TITLE
Puppeteer running tests in the same tab

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -9,6 +9,7 @@ module.exports = {
     headless: process.env.CI === 'true',
   },
   browserContext: process.env.INCOGNITO ? 'incognito' : 'default',
+  keepTabOpen: 'true',
   server: {
     command: `cross-env PORT=${port} node server`,
     port,


### PR DESCRIPTION
Allows the user to run tests in the same tab by keeping it open specifically the second tab.

## Summary

The point of this added feature is to have an option which lets multiple tests run in the same tab. We have about 19 tests which would run in a separate tab one after another(--runInBand), but because of the different tabs ( perhaps something to do with the cache of the browser) the information will get lost in the process and the tests would timeout. This would happen for a random number of tests.We also use docker to run all the tests, not just by terminal. 

## Test plan

I ran 15 tests for this example because the other 4 can't be used at the moment. A colleague is working on a bug which involves elements used in those 4 tests. I ran the "jest --runInBand <test1>, <test2>, ..." command in VS Code terminal to demonstrate the output.

This is the result using the same tab where 4/5 tries were successful and one try failing due to the timeout:

![test failed](https://user-images.githubusercontent.com/54394528/63580714-11769700-c59e-11e9-8415-9f0ea38bb3ec.jpg)

This is the result using the same tab where 5/5 tries were successful:

![tests passed](https://user-images.githubusercontent.com/54394528/63580715-11769700-c59e-11e9-854f-7841a7878508.jpg)

Note: The higher the number of tests , the higher the chance of multiple tests failing due to timeout.
Note 2: When the tests are run by docker , the chance of multiple tests failing is even higher.
